### PR TITLE
RainWorld Plush Fix

### DIFF
--- a/Resources/Prototypes/LCC/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/LCC/Entities/Objects/Fun/toys.yml
@@ -14,24 +14,24 @@
     heldPrefix: moon
   - type: EmitSoundOnUse
     sound:
-      path: LPP/Audio/Items/Toys/moon.ogg
+      path: Audio/LPP/Items/Toys/moon.ogg
   - type: EmitSoundOnLand
     sound:
-      path: LPP/Audio/Items/Toys/moon.ogg
+      path: Audio/LPP/Items/Toys/moon.ogg
   - type: EmitSoundOnActivate
     sound:
-      path: LPP/Audio/Items/Toys/moon.ogg
+      path: Audio/LPP/Items/Toys/moon.ogg
   - type: EmitSoundOnTrigger
     sound:
-      path: LPP/Audio/Items/Toys/moon.ogg
+      path: Audio/LPP/Items/Toys/moon.ogg
   - type: Food
     requiresSpecialDigestion: true
     useSound:
-      path: LPP/Audio/Items/Toys/moon.ogg
+      path: Audio/LPP/Items/Toys/moon.ogg
   - type: MeleeWeapon
     wideAnimationRotation: 180
     soundHit:
-      path: LPP/Audio/Items/Toys/moon.ogg
+      path: Audio/LPP/Items/Toys/moon.ogg
       
 - type: entity
   parent: BasePlushie
@@ -47,21 +47,21 @@
     heldPrefix: pebbles
   - type: EmitSoundOnUse
     sound:
-      path: LPP/Audio/Items/Toys/pebbles.ogg
+      path: Audio/LPP/Items/Toys/pebbles.ogg
   - type: EmitSoundOnLand
     sound:
-      path: LPP/Audio/Items/Toys/pebbles.ogg
+      path: Audio/LPP/Items/Toys/pebbles.ogg
   - type: EmitSoundOnActivate
     sound:
-      path: LPP/Audio/Items/Toys/pebbles.ogg
+      path: Audio/LPP/Items/Toys/pebbles.ogg
   - type: EmitSoundOnTrigger
     sound:
-      path: LPP/Audio/Items/Toys/pebbles.ogg
+      path: Audio/LPP/Items/Toys/pebbles.ogg
   - type: Food
     requiresSpecialDigestion: true
     useSound:
-      path: LPP/Audio/Items/Toys/pebbles.ogg
+      path: Audio/LPP/Items/Toys/pebbles.ogg
   - type: MeleeWeapon
     wideAnimationRotation: 180
     soundHit:
-      path: LPP/Audio/Items/Toys/pebbles.ogg
+      path: Audio/LPP/Items/Toys/pebbles.ogg


### PR DESCRIPTION
# VIVA LA LOST PARADISE!

**Описание обновления:**
Оказывается мой гениальный мозг неправильно написал путь к звукам, из за чего у плюшек их вообще не было
<!--                         Например.
 Я изменил все текстуры дверей на новые кроме, дверей ЦК и Адвоката.
 Добавил возможность развести костёр кликая заженной спичкой по бревну.-->


**Причина/Для чего**
<!-- Описывайте здесь зачем и по какой причине сделано данное обновление -->
Фикс

**Изменения**
:cl: no CL cuz i can
- fix: Исправлено Теперь плюшки Итераторов имеют звуки!

<!--
:cl: *Ваше имя. Можно и на русском*
- add: Добавлено *Что конкретно*.
- remove: Убрано *Что конкретно*.
- tweak: Изменено *Что конкретно*.
- fix: Исправлено *Что конкретно*.
-->

**Медиа**
<!-- Скрины или видео после этого пункта. Под ними ничего не дополнять!-->


